### PR TITLE
Fix character limit for the commit message subject

### DIFF
--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -22,11 +22,11 @@
             'match': '\\G((fixup|squash)!)\\s*'
           }
           {
-            'match': '.{66,}$'
+            'match': '.{65,}$'
             'name': 'invalid.illegal.line-too-long.git-commit'
           }
           {
-            'match': '.{51,}$'
+            'match': '.{50,}$'
             'name': 'invalid.deprecated.line-too-long.git-commit'
           }
         ]


### PR DESCRIPTION
The previous limits marked lines when they had 52/67 characters, not 51/66.