### PR TITLE
Add 'git/config' to fileTypes

### DIFF
--- a/grammars/git config.cson
+++ b/grammars/git config.cson
@@ -2,6 +2,7 @@
 'scopeName': 'source.git-config'
 'fileTypes': [
   '.git/config'
+  'git/config'
   '.gitconfig'
   'etc/gitconfig'
   '.gitmodules'


### PR DESCRIPTION
In [git config man page](https://git-scm.com/docs/git-config#FILES) file `$HOME/.config/git/config` is valid git config. So I added it.