### PR TITLE
Add snippets to the package

### DIFF
--- a/snippets/language-git.cson
+++ b/snippets/language-git.cson
@@ -1,0 +1,8 @@
+'.text.git-commit':
+  'commit-message':
+    'prefix': 'comm'
+    'body': """
+      ${1:Subject < 50 chars}
+
+      ${2:Body in detail}
+    """


### PR DESCRIPTION
I was configuring the language-git package for myself and saw that it was missing a snippets folder. I have added a '/snippets' folder to this package with '/snippets/language-git.cson' file. This file contains a snippet called 'Commit Message' that is activated by using the prefix 'comm'. The snippet will print a structured commit message placeholder with suggestions about character limit for both, subject line and body.