### PR TITLE
Revert "Add 'git/config' to fileTypes"

### DIFF
--- a/grammars/git config.cson
+++ b/grammars/git config.cson
@@ -2,7 +2,6 @@
 'scopeName': 'source.git-config'
 'fileTypes': [
   '.git/config'
-  'git/config'
   '.gitconfig'
   'etc/gitconfig'
   '.gitmodules'


### PR DESCRIPTION
(Temporarily) reverts atom/language-git#15

This breaks core specs due to a subtle bug in filepath matching.  Until we fix that, revert this PR so that we can keep adding other changes to language-git.