### PR TITLE
Recognize gitconfig, gitmodules without leading dot

### DIFF
--- a/grammars/git config.cson
+++ b/grammars/git config.cson
@@ -2,9 +2,8 @@
 'scopeName': 'source.git-config'
 'fileTypes': [
   '.git/config'
-  '.gitconfig'
-  'etc/gitconfig'
-  '.gitmodules'
+  'gitconfig'
+  'gitmodules'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Hi,

I've noticed that many of the language module packages for Atom allow for file names with *or* without a leading dot (for instance, the language-shellscript package will apply [its grammar](https://github.com/atom/language-shellscript/blob/master/grammars/shell-unix-bash.cson) to *either* `.bashrc` or `bashrc`.

This flexibility allows me to write my `bashrc` as a "visible" file; the file is still symlinked to my home directory as `.bashrc`, but the has the added benefit of being visible in search applications that ignore hidden files (like Spotlight and [Alfred](https://www.alfredapp.com/) on OS X).

Therefore, I have made a small change to the package grammar which allows for `gitconfig` to be recognized, in addition to `.gitconfig`. I was also going to add a test for this, though there didn't seem to be any clear way of doing so in the spec.

Let me know if there's anything I can add. :)
Caleb