### PR TITLE
Improve pattern-matching in commit messages

### DIFF
--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -13,10 +13,10 @@
     'name': 'meta.scope.message.git-commit'
     'patterns': [
       {
+        'match': '\\G((fixup|squash)!)'
         'captures':
           '1':
             'name': 'keyword.other.$2.git-commit'
-        'match': '\\G((fixup|squash)!)\\s*'
       }
       {
         'match': '^#.*$'

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -9,33 +9,35 @@
 'patterns': [
   {
     'begin': '\\A(?!#)'
-    'end': '(?=# Please enter the commit message)'
+    'end': '^(?<!\\A)(?=# Please enter the commit message)'
     'name': 'meta.scope.message.git-commit'
     'patterns': [
       {
-        'begin': '\\G'
-        'end': '^(?!\\G)'
-        'patterns': [
-          {
-            'captures':
-              '1':
-                'name': 'keyword.other.$2.git-commit'
-            'match': '\\G((fixup|squash)!)\\s*'
-          }
-          {
-            'match': '.{66,}$'
-            'name': 'invalid.illegal.line-too-long.git-commit'
-          }
-          {
-            'match': '.{51,}$'
-            'name': 'invalid.deprecated.line-too-long.git-commit'
-          }
-        ]
+        'captures':
+          '1':
+            'name': 'keyword.other.$2.git-commit'
+        'match': '\\G((fixup|squash)!)\\s*'
+      }
+      {
+        'match': '^#.*$'
+        'name': 'comment.line.number-sign.git-commit'
+      }
+      {
+        'match': '\\A(?!#).{70,}'
+        'name': 'invalid.illegal.line-too-long.git-commit'
+      }
+      {
+        'match': '\\A(?!#).{51,}'
+        'name': 'invalid.deprecated.line-too-long.git-commit'
+      }
+      {
+        'match': '^(?!#).{73,}'
+        'name': 'invalid.illegal.line-too-long.git-commit'
       }
     ]
   }
   {
-    'begin': '(?=# Please enter the commit message)'
+    'begin': '(?<=^)(?=# Please enter the commit message)'
     'end': '\\z'
     'name': 'meta.scope.metadata.git-commit'
     'patterns': [
@@ -81,7 +83,7 @@
         ]
       }
       {
-        'begin': '(^[ \\t]+)?(?=#)'
+        'begin': '^(?=#)'
         'beginCaptures':
           '1':
             'name': 'punctuation.whitespace.comment.leading.git-commit'


### PR DESCRIPTION
Fixes
-------

1. **Comments are now highlighted before the auto-generated _"Please enter…"_**.<br/><img src="https://cloud.githubusercontent.com/assets/2346707/15087298/0e24263a-142b-11e6-9aa7-e0634cec875e.png" alt="figure-1" width="498" /><br/><br/>
2. **Comments will only match at the start of a line, without whitespace**.<br/><img src="https://cloud.githubusercontent.com/assets/2346707/15087368/8f163fa8-142b-11e6-903a-8d058827c1d8.png" alt="figure-2" width="330" /><br/><br/>
3. **Maximum line-length for body raised from 66 to 72 to reflect [accepted best practices](http://chris.beams.io/posts/git-commit/#seven-rules)**.<br/><br/>
4. **Subject line's maximum length raised to 69, retaining 51 as a warning.**