### PR TITLE
Add syntax highlighting for drop command of interactive rebase

### DIFF
--- a/grammars/git rebase message.cson
+++ b/grammars/git rebase message.cson
@@ -19,7 +19,7 @@
         'name': 'constant.sha.git-rebase'
       '3':
         'name': 'meta.commit-message.git-rebase'
-    'match': '^\\s*(pick|p|reword|r|edit|e|squash|s|fixup|f)\\s+([0-9a-f]+)\\s+(.*)$'
+    'match': '^\\s*(pick|p|reword|r|edit|e|squash|s|fixup|f|drop|d)\\s+([0-9a-f]+)\\s+(.*)$'
     'name': 'meta.commit-command.git-rebase'
   }
 ]


### PR DESCRIPTION
`drop` command was added in git v2.6.0 (September 2015).
See https://git.kernel.org/cgit/git/git.git/tree/Documentation/RelNotes/2.6.0.txt.

Interactive rebase help message says: `d, drop = remove commit`.