### PR TITLE
Add support for exec command in rebase mode

### DIFF
--- a/grammars/git rebase message.cson
+++ b/grammars/git rebase message.cson
@@ -22,4 +22,17 @@
     'match': '^\\s*(pick|p|reword|r|edit|e|squash|s|fixup|f|drop|d)\\s+([0-9a-f]+)\\s+(.*)$'
     'name': 'meta.commit-command.git-rebase'
   }
+  {
+    'begin': '^\\s*(exec|x)\\s+'
+    'beginCaptures':
+      '1':
+        'name': 'support.function.git-rebase'
+    'end': '$'
+    'name': 'meta.exec-command.git-rebase'
+    'patterns': [
+      {
+        'include': 'source.shell'
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
This adds shell script syntax highlighting for the `exec`/`x` option.
See https://git-scm.com/docs/git-rebase#_interactive_mode

It was briefly discussed in https://github.com/atom/language-git/pull/20#issuecomment-224183660 so I figured I'd give it a try.

This is my first time approaching Atom's code (well, this is less code than configuration, to be fair) so it's very likely that I didn't end up with the best/easiest solution. A few notes:
- Tried and failed to use `captures`/`match`, switched to `beginCaptures`/`begin`/`end` instead. It seems to me that you cannot mix `match` with `include`, and that you cannot mix `captures` with `begin`.
- Tried and failed to use `$` or `\\n` for the `end` statement (I really expected the latter one to work), switched to `^` instead, to match the end of a line. Can you explain?
- Not too sure what the global `name` is for, so I might have chosen a bad one. Let me know if needs changing.

I feel like these notes will get a well-deserved RTFM, but the first link (anchor) [given here](https://discuss.atom.io/t/documentation-for-atom-grammars/6525) is now broken, and I quickly gave up on finding the correct resource.

Result looks like:

Before | After
--- | ---
<img width="632" alt="screen shot 2016-06-07 at 21 05 46" src="https://cloud.githubusercontent.com/assets/113730/15883265/8ae375b6-2d14-11e6-9d31-2d8a867bbf31.png"> | <img width="633" alt="screen shot 2016-06-07 at 21 06 01" src="https://cloud.githubusercontent.com/assets/113730/15883264/8ade15c6-2d14-11e6-8510-3b3f2c752c8f.png">