### PR TITLE
Highlight overflowing parts of lines only

### DIFF
--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -29,8 +29,10 @@
       }
       {
         # First line 51 chars or longer
-        'match': '\\A(?!#).{51,}'
-        'name': 'invalid.deprecated.line-too-long.git-commit'
+        'match': '\\A(?!#).{50}(.+)'
+        'captures':
+          '1':
+            'name': 'invalid.deprecated.line-too-long.git-commit'
       }
       {
         # Not-first-line 73 chars or longer

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -23,16 +23,21 @@
         'name': 'comment.line.number-sign.git-commit'
       }
       {
+        # First line 70 chars or longer
         'match': '\\A(?!#).{70,}'
         'name': 'invalid.illegal.line-too-long.git-commit'
       }
       {
+        # First line 51 chars or longer
         'match': '\\A(?!#).{51,}'
         'name': 'invalid.deprecated.line-too-long.git-commit'
       }
       {
-        'match': '^(?!#).{73,}'
-        'name': 'invalid.illegal.line-too-long.git-commit'
+        # Not-first-line 73 chars or longer
+        'match': '^(?!#).{72}(.+)'
+        'captures':
+          '1':
+            'name': 'invalid.illegal.line-too-long.git-commit'
       }
     ]
   }

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -24,12 +24,16 @@
       }
       {
         # First line 70 chars or longer
-        'match': '\\A(?!#).{70,}'
-        'name': 'invalid.illegal.line-too-long.git-commit'
+        'match': '\\A(?!#).{50}(.{19})(.+)'
+        'captures':
+          '1':
+            'name': 'invalid.deprecated.line-too-long.git-commit'
+          '2':
+            'name': 'invalid.illegal.line-too-long.git-commit'
       }
       {
-        # First line 51 chars or longer
-        'match': '\\A(?!#).{50}(.+)'
+        # First line 51-69 chars
+        'match': '\\A(?!#).{50}(.{0,19})'
         'captures':
           '1':
             'name': 'invalid.deprecated.line-too-long.git-commit'

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -23,7 +23,7 @@
         'name': 'comment.line.number-sign.git-commit'
       }
       {
-        # First line 70 chars or longer
+        # Subject line 70 chars or longer
         'match': '\\A(?!#).{50}(.{19})(.+)'
         'captures':
           '1':
@@ -32,14 +32,14 @@
             'name': 'invalid.illegal.line-too-long.git-commit'
       }
       {
-        # First line 51-69 chars
+        # Subject line 51-69 chars
         'match': '\\A(?!#).{50}(.{0,19})'
         'captures':
           '1':
             'name': 'invalid.deprecated.line-too-long.git-commit'
       }
       {
-        # Not-first-line 73 chars or longer
+        # Body line 73 chars or longer
         'match': '^(?!#).{72}(.+)'
         'captures':
           '1':


### PR DESCRIPTION
Before this change, if a line was too long the whole line was highlighted.

With this change in place, if a line is too long, only the overflowing part is highlighted. This makes it much easier to understand where the line needs to be broken.

For the git-commit grammar only for now.
