### PR TITLE
Commit message subject should be capitalized

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ You can configure Atom to be your Git editor with the following command:
 git config --global core.editor "atom --wait"
 ```
 
+## Commit message highlighting
+
+Violations of [The seven rules of a great git commit message](http://chris.beams.io/posts/git-commit/#seven-rules)
+are highlighted as follows:
+1. _Not highlighted_: Separate subject from body with a blank line
+2. _Overflow highlighted_: Limit the subject line to 50 characters
+3. _Initial lowercase letter is highlighted_: Capitalize the subject line
+4. _Not highlighted_: Do not end the subject line with a period
+5. _Not highlighted_: Use the imperative mood in the subject line
+6. _Overflow highlighted_: Wrap the body at 72 characters
+7. _Not highlighted_: Use the body to explain what and why vs. how
+
+
+## Background
+
 Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate) from the [Git TextMate bundle](https://github.com/textmate/git.tmbundle).
 
 Contributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,11 @@ git config --global core.editor "atom --wait"
 
 ## Commit message highlighting
 
-Violations of [The seven rules of a great git commit message](http://chris.beams.io/posts/git-commit/#seven-rules)
-are highlighted as follows:
-1. _Not highlighted_: Separate subject from body with a blank line
-2. _Overflow highlighted_: Limit the subject line to 50 characters
-3. _Initial lowercase letter is highlighted_: Capitalize the subject line
-4. _Not highlighted_: Do not end the subject line with a period
-5. _Not highlighted_: Use the imperative mood in the subject line
-6. _Overflow highlighted_: Wrap the body at 72 characters
-7. _Not highlighted_: Use the body to explain what and why vs. how
+This package uses warning and error highlighting to help bring attention to some violations of [standard conventions around commit message best practices](http://chris.beams.io/posts/git-commit/#seven-rules):
 
+1. If the subject line goes beyond 50 characters and again if it goes beyond 72 characters
+1. If the subject line begins with a lower-case letter (emoji at the beginning of the subject line won't be highlighted)
+1. If any non-comment body line goes beyond 72 characters
 
 ## Background
 

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -23,7 +23,8 @@
         'name': 'comment.line.number-sign.git-commit'
       }
       {
-        # See: http://chris.beams.io/posts/git-commit/#capitalize
+        # Subject line should be capitalized, see:
+        # http://chris.beams.io/posts/git-commit/#capitalize
         'match': '\\A[a-z]'
         'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
       }

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -23,6 +23,11 @@
         'name': 'comment.line.number-sign.git-commit'
       }
       {
+        # See: http://chris.beams.io/posts/git-commit/#capitalize
+        'match': '\\A[a-z]'
+        'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
+      }
+      {
         # Subject line 70 chars or longer
         'match': '\\A(?!#).{50}(.{19})(.+)'
         'captures':


### PR DESCRIPTION
Because: http://chris.beams.io/posts/git-commit/#capitalize

This is how violations are highlighted:
![skarmavbild 2016-11-19 kl 10 19 05](https://cloud.githubusercontent.com/assets/158201/20454456/a34f3d7a-ae41-11e6-87e9-9580ef92d789.png)
