### PR TITLE
Set Git Commit preferred line length to 72

### DIFF
--- a/settings/language-git.cson
+++ b/settings/language-git.cson
@@ -4,3 +4,4 @@
 '.text.git-commit':
   'editor':
     'foldEndPattern': '^---'
+    'preferredLineLength': 72


### PR DESCRIPTION
The seven rules...
http://chris.beams.io/posts/git-commit/#seven-rules
... say "Wrap the body at 72 characters".

So we should tell Atom that's the preferred line length.