### PR TITLE
Highlight subject line trailing period

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This package uses warning and error highlighting to help bring attention to some
 
 1. If the subject line goes beyond 50 characters and again if it goes beyond 72 characters
 1. If the subject line begins with a lower-case letter (emoji at the beginning of the subject line won't be highlighted)
+1. If the subject line ends with a period
 1. If any non-comment body line goes beyond 72 characters
 
 ## Background

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -46,7 +46,7 @@
       }
       {
         # Subject line 70 chars or longer
-        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,19})(.+)$'
+        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,19})(.*?)([.]?)$'
         'captures':
           '2':
             'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
@@ -54,6 +54,8 @@
             'name': 'invalid.deprecated.line-too-long.git-commit'
           '4':
             'name': 'invalid.illegal.line-too-long.git-commit'
+          '5':
+            'name': 'invalid.illegal.subject-no-trailing-period.git-commit'
       }
       {
         # Body line 73 chars or longer

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -23,26 +23,37 @@
         'name': 'comment.line.number-sign.git-commit'
       }
       {
-        # Subject line should be capitalized, see:
-        # http://chris.beams.io/posts/git-commit/#capitalize
-        'match': '\\A[a-z]'
-        'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
-      }
-      {
-        # Subject line 70 chars or longer
-        'match': '\\A(?!#).{50}(.{19})(.+)'
+        # Subject line 0-50 chars
+        'match': '\\A(?!#)(([a-z])|.).{0,48}((\\.)|.)$'
         'captures':
-          '1':
-            'name': 'invalid.deprecated.line-too-long.git-commit'
           '2':
-            'name': 'invalid.illegal.line-too-long.git-commit'
+            'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
+          '4':
+            'name': 'invalid.illegal.subject-no-trailing-period.git-commit'
       }
       {
         # Subject line 51-69 chars
-        'match': '\\A(?!#).{50}(.{0,19})'
+        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,18})((\\.)|(.))$'
         'captures':
-          '1':
+          '2':
+            'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
+          '3':
             'name': 'invalid.deprecated.line-too-long.git-commit'
+          '5':
+            'name': 'invalid.illegal.subject-no-trailing-period.git-commit'
+          '6':
+            'name': 'invalid.deprecated.line-too-long.git-commit'
+      }
+      {
+        # Subject line 70 chars or longer
+        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,19})(.+)$'
+        'captures':
+          '2':
+            'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
+          '3':
+            'name': 'invalid.deprecated.line-too-long.git-commit'
+          '4':
+            'name': 'invalid.illegal.line-too-long.git-commit'
       }
       {
         # Body line 73 chars or longer

--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -46,7 +46,7 @@
       }
       {
         # Subject line 70 chars or longer
-        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,19})(.*?)([.]?)$'
+        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,19})(.*?)(\\.?)$'
         'captures':
           '2':
             'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -14,6 +14,32 @@ describe "Git grammars", ->
       expect(grammar.scopeName).toBe "source.git-config"
 
   describe "Git commit messages", ->
+    beforeEach ->
+      grammar = atom.grammars.grammarForScopeName("text.git-commit")
+
+    it "parses the Git commit message grammar", ->
+      expect(grammar).toBeTruthy()
+      expect(grammar.scopeName).toBe "text.git-commit"
+
+    # Highlight a commit message subject and render the result as a string.
+    #
+    # Each characted in the returned string represents how the corresponding
+    # char in the input string is highlighted:
+    # " " means not highlighted
+    # "d" means highlighted as deprecated
+    # "i" means highlighted as illegal
+    #
+    # For example, highlighting of
+    # "b2345678901234567890123456789." will be rendered as
+    # "i                            i", meaning that the first and the last char
+    # of the input string are "illegal".
+    #
+    # This enables writing subject line highlighting tests visually.
+    #
+    # The name of the function is designed to be the same length as "toEqual",
+    # so that the input string and the rendered string can be aligned underneath
+    # each other in the test cases. Make sure you use a fixed-width font in your
+    # editor :-).
     hilight = (subject) ->
       {tokens} = grammar.tokenizeLine(subject, null, true)
       returnMe = ''
@@ -27,13 +53,6 @@ describe "Git grammars", ->
         returnMe += Array(token.value.length + 1).join(char)
 
       return returnMe
-
-    beforeEach ->
-      grammar = atom.grammars.grammarForScopeName("text.git-commit")
-
-    it "parses the Git commit message grammar", ->
-      expect(grammar).toBeTruthy()
-      expect(grammar.scopeName).toBe "text.git-commit"
 
     it "highlights subject lines of less than 50 chars correctly", ->
       expect(

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -14,17 +14,17 @@ describe "Git grammars", ->
       expect(grammar.scopeName).toBe "source.git-config"
 
   describe "Git commit messages", ->
-    scopeNormal =  [ 'text.git-commit', 'meta.scope.message.git-commit' ]
+    scopeNormal =  ['text.git-commit', 'meta.scope.message.git-commit']
 
     scopeLeadingLowercase =
-      [ 'text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.first-char-should-be-uppercase.git-commit' ]
+      ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.first-char-should-be-uppercase.git-commit']
 
     scopeTrailingPeriod =
-      [ 'text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.subject-no-trailing-period.git-commit' ]
+      ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.subject-no-trailing-period.git-commit']
 
-    scopeTooLong1 = [ 'text.git-commit', 'meta.scope.message.git-commit', 'invalid.deprecated.line-too-long.git-commit' ]
+    scopeLineOver50 = ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.deprecated.line-too-long.git-commit']
 
-    scopeTooLong2 = [ 'text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.line-too-long.git-commit' ]
+    scopeLineOver70 = ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.line-too-long.git-commit']
 
     beforeEach ->
       grammar = atom.grammars.grammarForScopeName("text.git-commit")
@@ -70,12 +70,12 @@ describe "Git grammars", ->
     it "highlights subject lines of 51 chars correctly", ->
       {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1', scopes: scopeTooLong1
+      expect(tokens[1]).toEqual value: '1', scopes: scopeLineOver50
 
       {tokens} = grammar.tokenizeLine("e23456789012345678901234567890123456789012345678901", null, true)
       expect(tokens[0]).toEqual value: 'e', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1', scopes: scopeTooLong1
+      expect(tokens[2]).toEqual value: '1', scopes: scopeLineOver50
 
       {tokens} = grammar.tokenizeLine("12345678901234567890123456789012345678901234567890.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
@@ -89,71 +89,71 @@ describe "Git grammars", ->
     it "highlights subject lines of 69 chars correctly", ->
       {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '123456789012345678', scopes: scopeTooLong1
-      expect(tokens[2]).toEqual value: '9', scopes: scopeTooLong1
+      expect(tokens[1]).toEqual value: '123456789012345678', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '9', scopes: scopeLineOver50
 
       {tokens} = grammar.tokenizeLine("g23456789012345678901234567890123456789012345678901234567890123456789", null, true)
       expect(tokens[0]).toEqual value: 'g', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '123456789012345678', scopes: scopeTooLong1
-      expect(tokens[3]).toEqual value: '9', scopes: scopeTooLong1
+      expect(tokens[2]).toEqual value: '123456789012345678', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '9', scopes: scopeLineOver50
 
       {tokens} = grammar.tokenizeLine("12345678901234567890123456789012345678901234567890123456789012345678.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '123456789012345678', scopes: scopeTooLong1
+      expect(tokens[1]).toEqual value: '123456789012345678', scopes: scopeLineOver50
       expect(tokens[2]).toEqual value: '.', scopes: scopeTrailingPeriod
 
       {tokens} = grammar.tokenizeLine("h2345678901234567890123456789012345678901234567890123456789012345678.", null, true)
       expect(tokens[0]).toEqual value: 'h', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '123456789012345678', scopes: scopeTooLong1
+      expect(tokens[2]).toEqual value: '123456789012345678', scopes: scopeLineOver50
       expect(tokens[3]).toEqual value: '.', scopes: scopeTrailingPeriod
 
     it "highlights subject lines of 70 chars correctly", ->
       {tokens} = grammar.tokenizeLine("1234567890123456789012345678901234567890123456789012345678901234567890", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[2]).toEqual value: '0', scopes: scopeTooLong2
+      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '0', scopes: scopeLineOver70
 
       {tokens} = grammar.tokenizeLine("i234567890123456789012345678901234567890123456789012345678901234567890", null, true)
       expect(tokens[0]).toEqual value: 'i', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[3]).toEqual value: '0', scopes: scopeTooLong2
+      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '0', scopes: scopeLineOver70
 
       {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[2]).toEqual value: '.', scopes: scopeTooLong2
+      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '.', scopes: scopeLineOver70
 
       {tokens} = grammar.tokenizeLine("j23456789012345678901234567890123456789012345678901234567890123456789.", null, true)
       expect(tokens[0]).toEqual value: 'j', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[3]).toEqual value: '.', scopes: scopeTooLong2
+      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '.', scopes: scopeLineOver70
 
     it "highlights subject lines of over 70 chars correctly", ->
       {tokens} = grammar.tokenizeLine("12345678901234567890123456789012345678901234567890123456789012345678901234", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[2]).toEqual value: '01234', scopes: scopeTooLong2
+      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '01234', scopes: scopeLineOver70
 
       {tokens} = grammar.tokenizeLine("k2345678901234567890123456789012345678901234567890123456789012345678901234", null, true)
       expect(tokens[0]).toEqual value: 'k', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[3]).toEqual value: '01234', scopes: scopeTooLong2
+      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '01234', scopes: scopeLineOver70
 
       {tokens} = grammar.tokenizeLine("1234567890123456789012345678901234567890123456789012345678901234567890123.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[2]).toEqual value: '0123.', scopes: scopeTooLong2
+      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '0123.', scopes: scopeLineOver70
 
       {tokens} = grammar.tokenizeLine("m234567890123456789012345678901234567890123456789012345678901234567890123.", null, true)
       expect(tokens[0]).toEqual value: 'm', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeTooLong1
-      expect(tokens[3]).toEqual value: '0123.', scopes: scopeTooLong2
+      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '0123.', scopes: scopeLineOver70
 
   describe "Git rebases", ->
     beforeEach ->

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -124,13 +124,13 @@ describe "Git grammars", ->
       {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
       expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[2]).toEqual value: '.', scopes: scopeLineOver70
+      expect(tokens[2]).toEqual value: '.', scopes: scopeTrailingPeriod
 
       {tokens} = grammar.tokenizeLine("j23456789012345678901234567890123456789012345678901234567890123456789.", null, true)
       expect(tokens[0]).toEqual value: 'j', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
       expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[3]).toEqual value: '.', scopes: scopeLineOver70
+      expect(tokens[3]).toEqual value: '.', scopes: scopeTrailingPeriod
 
     it "highlights subject lines of over 70 chars correctly", ->
       {tokens} = grammar.tokenizeLine("12345678901234567890123456789012345678901234567890123456789012345678901234", null, true)
@@ -147,13 +147,15 @@ describe "Git grammars", ->
       {tokens} = grammar.tokenizeLine("1234567890123456789012345678901234567890123456789012345678901234567890123.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
       expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[2]).toEqual value: '0123.', scopes: scopeLineOver70
+      expect(tokens[2]).toEqual value: '0123', scopes: scopeLineOver70
+      expect(tokens[3]).toEqual value: '.', scopes: scopeTrailingPeriod
 
       {tokens} = grammar.tokenizeLine("m234567890123456789012345678901234567890123456789012345678901234567890123.", null, true)
       expect(tokens[0]).toEqual value: 'm', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
       expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[3]).toEqual value: '0123.', scopes: scopeLineOver70
+      expect(tokens[3]).toEqual value: '0123', scopes: scopeLineOver70
+      expect(tokens[4]).toEqual value: '.', scopes: scopeTrailingPeriod
 
   describe "Git rebases", ->
     beforeEach ->

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -14,12 +14,111 @@ describe "Git grammars", ->
       expect(grammar.scopeName).toBe "source.git-config"
 
   describe "Git commit messages", ->
+    hilight = (subject) ->
+      {tokens} = grammar.tokenizeLine(subject, null, true)
+      returnMe = ''
+      for token in tokens
+        char = ' '
+        for scope in token.scopes
+          char = 'd' if scope.match(/deprecated/)
+          char = 'i' if scope.match(/illegal/)
+
+        # From: https://coffeescript-cookbook.github.io/chapters/strings/repeating
+        returnMe += Array(token.value.length + 1).join(char)
+
+      return returnMe
+
     beforeEach ->
       grammar = atom.grammars.grammarForScopeName("text.git-commit")
 
     it "parses the Git commit message grammar", ->
       expect(grammar).toBeTruthy()
       expect(grammar.scopeName).toBe "text.git-commit"
+
+    it "highlights subject lines of less than 50 chars correctly", ->
+      expect(
+        hilight("123456789012345678901234567890")).
+        toEqual("                              ")
+      expect(
+        hilight("a23456789012345678901234567890")).
+        toEqual("i                             ")
+      expect(
+        hilight("12345678901234567890123456789.")).
+        toEqual("                             i")
+      expect(
+        hilight("b2345678901234567890123456789.")).
+        toEqual("i                            i")
+
+    it "highlights subject lines of 50 chars correctly", ->
+      expect(
+        hilight("12345678901234567890123456789012345678901234567890")).
+        toEqual("                                                  ")
+      expect(
+        hilight("c2345678901234567890123456789012345678901234567890")).
+        toEqual("i                                                 ")
+      expect(
+        hilight("1234567890123456789012345678901234567890123456789.")).
+        toEqual("                                                 i")
+      expect(
+        hilight("d234567890123456789012345678901234567890123456789.")).
+        toEqual("i                                                i")
+
+    it "highlights subject lines of 51 chars correctly", ->
+      expect(
+        hilight("123456789012345678901234567890123456789012345678901")).
+        toEqual("                                                  d")
+      expect(
+        hilight("e23456789012345678901234567890123456789012345678901")).
+        toEqual("i                                                 d")
+      expect(
+        hilight("12345678901234567890123456789012345678901234567890.")).
+        toEqual("                                                  i")
+      expect(
+        hilight("f2345678901234567890123456789012345678901234567890.")).
+        toEqual("i                                                 i")
+
+    it "highlights subject lines of 69 chars correctly", ->
+      expect(
+        hilight("123456789012345678901234567890123456789012345678901234567890123456789")).
+        toEqual("                                                  ddddddddddddddddddd")
+      expect(
+        hilight("g23456789012345678901234567890123456789012345678901234567890123456789")).
+        toEqual("i                                                 ddddddddddddddddddd")
+      expect(
+        hilight("12345678901234567890123456789012345678901234567890123456789012345678.")).
+        toEqual("                                                  ddddddddddddddddddi")
+      expect(
+        hilight("h2345678901234567890123456789012345678901234567890123456789012345678.")).
+        toEqual("i                                                 ddddddddddddddddddi")
+
+    it "highlights subject lines of 70 chars correctly", ->
+      # 70 chars
+      expect(
+        hilight("1234567890123456789012345678901234567890123456789012345678901234567890")).
+        toEqual("                                                  dddddddddddddddddddi")
+      expect(
+        hilight("g234567890123456789012345678901234567890123456789012345678901234567890")).
+        toEqual("i                                                 dddddddddddddddddddi")
+      expect(
+        hilight("123456789012345678901234567890123456789012345678901234567890123456789.")).
+        toEqual("                                                  dddddddddddddddddddi")
+      expect(
+        hilight("h23456789012345678901234567890123456789012345678901234567890123456789.")).
+        toEqual("i                                                 dddddddddddddddddddi")
+
+    it "highlights subject lines of over 70 chars correctly", ->
+      expect(
+        hilight("12345678901234567890123456789012345678901234567890123456789012345678901234")).
+        toEqual("                                                  dddddddddddddddddddiiiii")
+      expect(
+        hilight("g2345678901234567890123456789012345678901234567890123456789012345678901234")).
+        toEqual("i                                                 dddddddddddddddddddiiiii")
+      expect(
+        hilight("1234567890123456789012345678901234567890123456789012345678901234567890123.")).
+        toEqual("                                                  dddddddddddddddddddiiiii")
+      expect(
+        hilight("h234567890123456789012345678901234567890123456789012345678901234567890123.")).
+        toEqual("i                                                 dddddddddddddddddddiiiii")
 
   describe "Git rebases", ->
     beforeEach ->


### PR DESCRIPTION
Because http://chris.beams.io/posts/git-commit/#seven-rules says: "Do
not end the subject line with a period".

This change comes with unit tests for the subject line highlighting
and as such most likely fixes issues with the previous highlighting
as well.