### PR TITLE
Suggest installing language-diff package for better highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This package uses warning and error highlighting to help bring attention to some
 1. If the subject line begins with a lower-case letter (emoji at the beginning of the subject line won't be highlighted)
 1. If any non-comment body line goes beyond 72 characters
 
+## Diff highlighting
+
+If [language-diff](https://atom.io/packages/language-diff) is installed, the
+diff part of `git commit --verbose` messages is highlighted as well.
+
 ## Background
 
 Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate) from the [Git TextMate bundle](https://github.com/textmate/git.tmbundle).


### PR DESCRIPTION
If language-diff is installed that will improve git commit --verbose
message highlighing.

This change adds this information to the README.