### PR TITLE
Fix to recognize git config files in all locations

### DIFF
--- a/grammars/git config.cson
+++ b/grammars/git config.cson
@@ -1,7 +1,7 @@
 'name': 'Git Config'
 'scopeName': 'source.git-config'
 'fileTypes': [
-  '.git/config'
+  'git/config'
   'gitconfig'
   'gitmodules'
 ]


### PR DESCRIPTION
As noted [at git-scm](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration), Git looks in a number of locations for config files.

-   system: `/etc/gitconfig`
-   global: `~/.gitconfig` or `~/.config/git/config`
-   local: `.git/config` of the current repo

The current file types do not account for the global `~/.config/git/config` location. Removing the dot (period) before `.git/config` allows detection of this global location.

Additionally, it is somewhat common to encounter a global git config file with an alternative filename (e.g `gitconfig_global`).