### PR TITLE
Add keyboard shortcuts for rebasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ This package uses warning and error highlighting to help bring attention to some
 1. If the subject line ends with a period
 1. If any non-comment body line goes beyond 72 characters
 
+## Rebase message keyboard shortcuts
+
+When rebasing, `git` tells you that you can `p`ick, `r`eword, `e`dit, `s`quash,
+`d`rop or `f`ixup changes.
+
+With language-git, just pressing the initial letter will switch the verb on the
+current line to the indicated one, and place the cursor at the start of the
+current line.
+
 ## Background
 
 Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate) from the [Git TextMate bundle](https://github.com/textmate/git.tmbundle).

--- a/keymaps/rebase.cson
+++ b/keymaps/rebase.cson
@@ -1,0 +1,7 @@
+"atom-text-editor[data-grammar='text git-rebase']":
+  'p': 'language-git:pick'
+  'r': 'language-git:reword'
+  'e': 'language-git:edit'
+  'f': 'language-git:fixup'
+  's': 'language-git:squash'
+  'd': 'language-git:drop'

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,0 +1,41 @@
+{CompositeDisposable} = require 'atom'
+
+module.exports = GitGrammar =
+  activate: (state) ->
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add('atom-text-editor', 'language-git:pick': @insertCommand)
+    @subscriptions.add atom.commands.add('atom-text-editor', 'language-git:reword': @insertCommand)
+    @subscriptions.add atom.commands.add('atom-text-editor', 'language-git:edit': @insertCommand)
+    @subscriptions.add atom.commands.add('atom-text-editor', 'language-git:squash': @insertCommand)
+    @subscriptions.add atom.commands.add('atom-text-editor', 'language-git:fixup': @insertCommand)
+    @subscriptions.add atom.commands.add('atom-text-editor', 'language-git:drop': @insertCommand)
+
+  deactivate: ->
+    @subscriptions.dispose()
+
+  insertCommand: (event) ->
+    command = /.*:([a-z]+)/.exec(event.type)[1]
+
+    editor = atom.workspace.getActiveTextEditor()
+
+    # Extract the whole current line
+    row = editor.getCursorBufferPosition().row
+    line = editor.lineTextForBufferRow(row)
+
+    # Extract the hash and the comment from the line
+    rebaseLine = /^[a-z]* *([0-9a-f]{7,} .*$)/
+    match = rebaseLine.exec(line)
+    if not match
+      editor.insertText(event.originalEvent.key)
+      return
+    hashAndComment = match[1]
+
+    # Replace the rebase command
+    newLine = "#{command} #{hashAndComment}"
+    return if newLine is line
+    lineRange = [[row, 0], [row, line.length]]
+    editor.setTextInBufferRange(lineRange, newLine)
+
+    # Position the cursor at the beginning of the line to enable a workflow of
+    # press-a-command, down, press-a-command, down, ...
+    editor.setCursorBufferPosition([row, 0])

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "atom": "*",
     "node": "*"
   },
+  "main": "lib/index",
   "homepage": "http://atom.github.io/language-git",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When doing a rebase, git lists a number of verbs (pick, drop, edit, ...)
that can be applied to each change in the rebase.

All these verbs come with a single letter abbreviation.

With this change in place, in Git Rebase Message mode, pressing that
single letter on a line will replace the verb on that line with the one
you indicated.

These shortcuts are active only when:
* You are editing a file in Git Rebase Message mode
* You are on a line denoting a change

For other lines in the rebase messages, like comments or exec lines, all
keys work as usual.

I have tested this by having a buffer in Git Rebase Message mode and
typing on commit lines, exec lines, empty lines and comment lines. I
have successfully tested typing both lowercase and uppercase letters on
the non-commit lines.