### PR TITLE
Increase maximum subject length to 72

### DIFF
--- a/grammars/git commit message.cson
+++ b/grammars/git commit message.cson
@@ -32,8 +32,8 @@
             'name': 'invalid.illegal.subject-no-trailing-period.git-commit'
       }
       {
-        # Subject line 51-69 chars
-        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,18})((\\.)|(.))$'
+        # Subject line 51-72 chars
+        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,21})((\\.)|(.))$'
         'captures':
           '2':
             'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'
@@ -45,8 +45,8 @@
             'name': 'invalid.deprecated.line-too-long.git-commit'
       }
       {
-        # Subject line 70 chars or longer
-        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,19})(.*?)(\\.?)$'
+        # Subject line 73 chars or longer
+        'match': '\\A(?!#)(([a-z])|.).{49}(.{0,22})(.*?)(\\.?)$'
         'captures':
           '2':
             'name': 'invalid.illegal.first-char-should-be-uppercase.git-commit'

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -24,7 +24,7 @@ describe "Git grammars", ->
 
     scopeLineOver50 = ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.deprecated.line-too-long.git-commit']
 
-    scopeLineOver70 = ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.line-too-long.git-commit']
+    scopeLineOver72 = ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.line-too-long.git-commit']
 
     beforeEach ->
       grammar = atom.grammars.grammarForScopeName("text.git-commit")
@@ -86,75 +86,75 @@ describe "Git grammars", ->
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
       expect(tokens[2]).toEqual value: '.', scopes: scopeTrailingPeriod
 
-    it "highlights subject lines of 69 chars correctly", ->
-      {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789", null, true)
+    it "highlights subject lines of 72 chars correctly", ->
+      {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789012", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '123456789012345678', scopes: scopeLineOver50
-      expect(tokens[2]).toEqual value: '9', scopes: scopeLineOver50
+      expect(tokens[1]).toEqual value: '123456789012345678901', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '2', scopes: scopeLineOver50
 
-      {tokens} = grammar.tokenizeLine("g23456789012345678901234567890123456789012345678901234567890123456789", null, true)
+      {tokens} = grammar.tokenizeLine("g23456789012345678901234567890123456789012345678901234567890123456789012", null, true)
       expect(tokens[0]).toEqual value: 'g', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '123456789012345678', scopes: scopeLineOver50
-      expect(tokens[3]).toEqual value: '9', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '123456789012345678901', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '2', scopes: scopeLineOver50
 
-      {tokens} = grammar.tokenizeLine("12345678901234567890123456789012345678901234567890123456789012345678.", null, true)
+      {tokens} = grammar.tokenizeLine("12345678901234567890123456789012345678901234567890123456789012345678901.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '123456789012345678', scopes: scopeLineOver50
+      expect(tokens[1]).toEqual value: '123456789012345678901', scopes: scopeLineOver50
       expect(tokens[2]).toEqual value: '.', scopes: scopeTrailingPeriod
 
-      {tokens} = grammar.tokenizeLine("h2345678901234567890123456789012345678901234567890123456789012345678.", null, true)
+      {tokens} = grammar.tokenizeLine("h2345678901234567890123456789012345678901234567890123456789012345678901.", null, true)
       expect(tokens[0]).toEqual value: 'h', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '123456789012345678', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '123456789012345678901', scopes: scopeLineOver50
       expect(tokens[3]).toEqual value: '.', scopes: scopeTrailingPeriod
 
-    it "highlights subject lines of 70 chars correctly", ->
-      {tokens} = grammar.tokenizeLine("1234567890123456789012345678901234567890123456789012345678901234567890", null, true)
+    it "highlights subject lines of 73 chars correctly", ->
+      {tokens} = grammar.tokenizeLine("1234567890123456789012345678901234567890123456789012345678901234567890123", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[2]).toEqual value: '0', scopes: scopeLineOver70
+      expect(tokens[1]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '3', scopes: scopeLineOver72
 
-      {tokens} = grammar.tokenizeLine("i234567890123456789012345678901234567890123456789012345678901234567890", null, true)
+      {tokens} = grammar.tokenizeLine("i234567890123456789012345678901234567890123456789012345678901234567890123", null, true)
       expect(tokens[0]).toEqual value: 'i', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[3]).toEqual value: '0', scopes: scopeLineOver70
+      expect(tokens[2]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '3', scopes: scopeLineOver72
 
-      {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789.", null, true)
+      {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789012.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[1]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
       expect(tokens[2]).toEqual value: '.', scopes: scopeTrailingPeriod
 
-      {tokens} = grammar.tokenizeLine("j23456789012345678901234567890123456789012345678901234567890123456789.", null, true)
+      {tokens} = grammar.tokenizeLine("j23456789012345678901234567890123456789012345678901234567890123456789012.", null, true)
       expect(tokens[0]).toEqual value: 'j', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
       expect(tokens[3]).toEqual value: '.', scopes: scopeTrailingPeriod
 
-    it "highlights subject lines of over 70 chars correctly", ->
-      {tokens} = grammar.tokenizeLine("12345678901234567890123456789012345678901234567890123456789012345678901234", null, true)
+    it "highlights subject lines of over 73 chars correctly", ->
+      {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789012345678", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[2]).toEqual value: '01234', scopes: scopeLineOver70
+      expect(tokens[1]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '345678', scopes: scopeLineOver72
 
-      {tokens} = grammar.tokenizeLine("k2345678901234567890123456789012345678901234567890123456789012345678901234", null, true)
+      {tokens} = grammar.tokenizeLine("k23456789012345678901234567890123456789012345678901234567890123456789012345678", null, true)
       expect(tokens[0]).toEqual value: 'k', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[3]).toEqual value: '01234', scopes: scopeLineOver70
+      expect(tokens[2]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '345678', scopes: scopeLineOver72
 
-      {tokens} = grammar.tokenizeLine("1234567890123456789012345678901234567890123456789012345678901234567890123.", null, true)
+      {tokens} = grammar.tokenizeLine("123456789012345678901234567890123456789012345678901234567890123456789012345678.", null, true)
       expect(tokens[0]).toEqual value: '12345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[1]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[2]).toEqual value: '0123', scopes: scopeLineOver70
+      expect(tokens[1]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
+      expect(tokens[2]).toEqual value: '345678', scopes: scopeLineOver72
       expect(tokens[3]).toEqual value: '.', scopes: scopeTrailingPeriod
 
-      {tokens} = grammar.tokenizeLine("m234567890123456789012345678901234567890123456789012345678901234567890123.", null, true)
+      {tokens} = grammar.tokenizeLine("m23456789012345678901234567890123456789012345678901234567890123456789012345678.", null, true)
       expect(tokens[0]).toEqual value: 'm', scopes: scopeLeadingLowercase
       expect(tokens[1]).toEqual value: '2345678901234567890123456789012345678901234567890', scopes: scopeNormal
-      expect(tokens[2]).toEqual value: '1234567890123456789', scopes: scopeLineOver50
-      expect(tokens[3]).toEqual value: '0123', scopes: scopeLineOver70
+      expect(tokens[2]).toEqual value: '1234567890123456789012', scopes: scopeLineOver50
+      expect(tokens[3]).toEqual value: '345678', scopes: scopeLineOver72
       expect(tokens[4]).toEqual value: '.', scopes: scopeTrailingPeriod
 
   describe "Git rebases", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

At over 50 characters; the subject line is marked as deprecated; at over 69, it was marked as illegal. I increased that to 72 characters before marking it as illegal, in accordance with an update to the article which the README says the recommendations are drawn from.

In particular, the maximum subject length is based on GitHub's subject truncation,
which truncates subjects greater than 72 characters to 69 characters. I believe that’s where the 69 showed up originally. For subjects longer than 72 characters, GitHub shows the first 69 followed by a three-character ellipsis, but for subjects of up to 72 characters there is no truncation.

See cbeams/chris.beams.io@cce2c9f for details.

### Alternate Designs

The maximum line length for the subject could be setting instead of hardcoded; I didn’t choose this because I only started using Atom yesterday and have no clue how to make that change, and I’m not sure how much demand there would be for it anyway.

### Benefits

The plugin more closely matches the guidelines it references, and indirectly more closely follows GitHub’s behavior.

### Possible Drawbacks

If anybody does prefer the shorter maximum subject length, this will stop marking those three characters as problematic. This could be fixed by making this a setting, as discussed above.

### Applicable Issues

None; I opened this PR without submitting an issue first, and no open issues discuss this.
